### PR TITLE
Update pupl_interp.m

### DIFF
--- a/process/pupl_interp.m
+++ b/process/pupl_interp.m
@@ -116,15 +116,15 @@ end
 function v = applyinterpolation(f, v, n, m)
 
 interpidx = ic_fft(isnan(v), n, 'most');
-s = find([false diff(interpidx) == 1]);
-e = find([diff(interpidx) == -1 false]);
+s = find([interpidx(1),diff(interpidx) == 1]);
+e = find([diff(interpidx) == -1, interpidx(end)]);
 if ~isempty(s) && ~isempty(e)
-    if s(1) > e(1)
-        e(1) = [];
+    if s(1) == 1
+        interpidx(s(1):e(1)) = false;
+    elseif e(end) == length(interpidx);
+        interpidx(s(end):e(end)) = false;
     end
-    if s(end) > e(end)
-        s(end) = [];
-    end
+
     for ii = 1:numel(s)
         if abs(v(s(ii)) - v(e(ii))) > m
             interpidx(s(ii):e(ii)) = false;


### PR DESCRIPTION
{ s = find([interpidx(1),diff(interpidx) == 1]); e = find([diff(interpidx) == -1, interpidx(end)]); }
This to get all the start and end index with their length always the same, so i think we don't need the
{ if s(1) > e(1), e(1) = []; end,  if s(end) > e(end), s(end) = []; end } anymore.

{ if s(1) == 1, interpidx(s(1):e(1)) = false; , elseif e(end) == npoints, interpidx(s(end):e(end)) = false; end}
This is to make cubic interpolation skip the begining and last nan cluster to avoid make negative value. 

By the way, i think pupl is bettter than chap and gazer, thank you for your work.